### PR TITLE
disable '@typescript-eslint/indent' rule ...

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   rules: {
     indent: 'off',
-    '@typescript-eslint/indent': ['warn', 2],
+    '@typescript-eslint/indent': 'off',
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/class-name-casing': 'error',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   rules: {
     indent: 'off',
-    '@typescript-eslint/indent': 'off',
+    '@typescript-eslint/indent': 'off', // Prettier already takes care of this.
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/class-name-casing': 'error',
     '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
as it has conflict with prettier one:

You can see result here:
https://monosnap.com/file/UuFp8lkVqdpiWYsjYjNjJob4hgIRgL
Every time I am on `select-category-company` tab I save file with `cmd + s`.
With rule `@typescript-eslint/indent` enabled, you can see problems every second click,
when we disable this, indentation works correctly, more info here:
https://github.com/typescript-eslint/typescript-eslint/issues/372#issuecomment-475865344