### PR TITLE
Extending TypeScript config `lines-between-class-members` rule

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -39,7 +39,12 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': 'error'
+    '@typescript-eslint/no-useless-constructor': 'error',
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: true }
+    ]
   },
   overrides: [
     {


### PR DESCRIPTION
So that its ignored for one-liners for nice formatting.