### PR TITLE
Adding the env override for .eslintrc.js files

### DIFF
--- a/packages/eslint-config-browser/lib/common.js
+++ b/packages/eslint-config-browser/lib/common.js
@@ -10,5 +10,12 @@ module.exports = {
   rules: {
     'unicorn/prefer-add-event-listener': 'error',
     'unicorn/prefer-text-content': 'error'
+  },
+  overrides: {
+    files: ['**/.eslintrc.js'],
+    env: {
+      node: true,
+      browser: false
+    }
   }
 };


### PR DESCRIPTION
So that we don't have to bloat the `.eslintrc.js` files with `/* eslint-env node */` comments