### PR TITLE
Fixing the 'overrides' config option

### DIFF
--- a/packages/eslint-config-browser/lib/common.js
+++ b/packages/eslint-config-browser/lib/common.js
@@ -11,11 +11,13 @@ module.exports = {
     'unicorn/prefer-add-event-listener': 'error',
     'unicorn/prefer-text-content': 'error'
   },
-  overrides: {
-    files: ['**/.eslintrc.js'],
-    env: {
-      node: true,
-      browser: false
+  overrides: [
+    {
+      files: ['**/.eslintrc.js'],
+      env: {
+        node: true,
+        browser: false
+      }
     }
-  }
+  ]
 };


### PR DESCRIPTION
The config `overrides` option landed with https://github.com/ClarkSource/eslint-config/pull/134 is of incorrect type. I've overlooked that it should have been an array.